### PR TITLE
Support link aliases

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,8 +1,8 @@
 export const MM_VIEW_TYPE = 'mindmap';
-export const MD_VIEW_TYPE = 'markdown'; 
+export const MD_VIEW_TYPE = 'markdown';
 
-// https://regex101.com/r/gw85cc/2
-export const INTERNAL_LINK_REGEX = /\[\[(?<wikitext>.*)\]\]|<a href="(?<mdpath>.*)">(?<mdtext>.*)<\/a>/gim;
+// https://regex101.com/r/aWdgvf/1
+export const INTERNAL_LINK_REGEX = /\[\[(?<wikitext>.*?)((\|)(?<wikialias>.*)\]\]|\]\])|<a href="(?<mdpath>.*)">(?<mdtext>.*)<\/a>/gim;
 
 // https://regex101.com/r/Yg7HuO/2
 export const FRONT_MATTER_REGEX = /^(---)$.+?^(---)$.+?/ims;

--- a/src/obsidian-markmap-plugin.ts
+++ b/src/obsidian-markmap-plugin.ts
@@ -21,8 +21,14 @@ export default class ObsidianMarkmap {
         for (let i = 0; i < matches.length; i++) {
             const match = matches[i];
             const isWikiLink = match.groups['wikitext'];
-            const linkText = isWikiLink ? match.groups['wikitext'] : match.groups['mdtext'];
-            const linkPath = isWikiLink ? linkText : match.groups['mdpath'];
+            var linkText, linkPath;
+            if (isWikiLink) {
+                linkText = match.groups['wikialias'] ? match.groups['wikialias'] : match.groups['wikitext'];
+                linkPath = match.groups['wikitext'];
+            } else {
+                linkText = match.groups['mdtext'];
+                linkPath = match.groups['mdpath'];
+            }
             if(linkPath.startsWith('http')){
                 continue;
             }


### PR DESCRIPTION
## Description
These changes enable using internal links with aliases (like `[[first file|alias name]]`). Without these changes such links were rendered in the wrong way and were unclickable.

## Issues
Closes #56, #75

## New behaviour
<img width="833" alt="image" src="https://user-images.githubusercontent.com/9114994/185713943-53df92d6-27fe-4c06-935a-fe3cf12cbfc6.png">
