### PR TITLE
Add regex for tags #54 and fix opening of mind map #97

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -6,3 +6,4 @@ export const INTERNAL_LINK_REGEX = /\[\[(?<wikitext>.*)\]\]|<a href="(?<mdpath>.
 
 // https://regex101.com/r/Yg7HuO/2
 export const FRONT_MATTER_REGEX = /^(---)$.+?^(---)$.+?/ims;
+export const TAG_REGEX = /#[a-z0-9_-]+/g;

--- a/src/main.ts
+++ b/src/main.ts
@@ -20,14 +20,7 @@ import { MindMapSettingsTab } from './settings-tab';
       console.log("Loading Mind Map plugin");
       this.vault = this.app.vault;
       this.workspace = this.app.workspace;
-      this.settings = Object.assign({
-        splitDirection: 'Horizontal',
-        nodeMinHeight: 16,
-        lineHeight: '1em',
-        spacingVertical: 5,
-        spacingHorizontal: 80,
-        paddingX: 8
-    }, await this.loadData());
+      this.settings = (await this.loadData()) || new MindMapSettings();
 
       this.registerView(
         MM_VIEW_TYPE,

--- a/src/mindmap-view.ts
+++ b/src/mindmap-view.ts
@@ -2,7 +2,7 @@ import { EventRef, ItemView, Menu, Vault, Workspace, WorkspaceLeaf } from 'obsid
 import { transform } from 'markmap-lib';
 import { Markmap } from 'markmap-view';
 import { INode } from 'markmap-common';
-import { FRONT_MATTER_REGEX, MD_VIEW_TYPE, MM_VIEW_TYPE } from './constants';
+import { FRONT_MATTER_REGEX, TAG_REGEX, MD_VIEW_TYPE, MM_VIEW_TYPE } from './constants';
 import ObsidianMarkmap from './obsidian-markmap-plugin';
 import { createSVG, getComputedCss, removeExistingSVG } from './markmap-svg';
 import { copyImageToClipboard } from './copy-image';
@@ -162,6 +162,9 @@ export default class MindmapView extends ItemView {
         let md = await this.app.vault.adapter.read(this.filePath);
         if(md.startsWith('---')) {
             md = md.replace(FRONT_MATTER_REGEX, '');
+        }
+        if(md.startsWith('#')) {
+            md = md.replace(TAG_REGEX, '');
         }
         const markDownHasChanged = this.currentMd != md;
         this.currentMd = md;


### PR DESCRIPTION
I fixed that the tags in the first line are not showing in the mind map (#54). Also the new commit in main branch (https://github.com/lynchjames/obsidian-mind-map/commit/48c73460c82d3ca58131bedf26fcfea74c007487) broke the mind map in the new version of Obsidian. I applied the old line of code. This works for me. 

Obsidian version: 1.0.3 

![Bildschirmfoto vom 2022-11-08 22-52-01](https://user-images.githubusercontent.com/63802292/200684556-051c6340-a483-49d7-9274-2231a5e7f0f5.png)
