### PR TITLE
Upgrade markmap to 0.14.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,11 @@ Note: On some machines the `.obsidian` folder may be hidden. On MacOS you should
 ## For developers
 Pull requests are both welcome and appreciated. 😀
 
+- Use the version of node that matches what is in `.github/workflows/release.yml`. (If using nvm: `nvm install lts/fermium`, `nvm use lts/fermium`).
+- Get set up with `npm install --verbose`, and then `npm run dev`.
+- Use a test vault with either the `test-vault/` in this repo, or manually install this to another test vault. (You may do so by symlinking, e.g. `ln -s <path to obsidian-mind-map/ <your vault>/.obsidian/plugins/.`, and then symlinking the built artifact to the root git dir `ln -s dist/main.js .`)
+- Since Obsidian desktop is an Electron app, you can use the Chromium developer tools to view an in-app console. `Cmd + Opt + I` on macOS or `Ctrl + Shift + I` on Windows/Linux.
+
 If you would like to contribute to the development of this plugin, please follow the guidelines provided in [CONTRIBUTING.md](CONTRIBUTING.md).
 
 ## Donating

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "obsidian-mind-map",
   "name": "Mind Map",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "A plugin to preview notes as Markmap mind maps",
   "isDesktopOnly": false,
   "js": "main.js"

--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
     "typescript": "^4.1.2"
   },
   "dependencies": {
-    "markmap-lib": "^0.10.2",
-    "markmap-view": "^0.1.2"
+    "markmap-lib": "^0.14.3",
+    "markmap-view": "^0.14.3",
+    "markmap-common": "^0.14.2"
   }
 }

--- a/src/mindmap-view.ts
+++ b/src/mindmap-view.ts
@@ -1,13 +1,12 @@
 import { EventRef, ItemView, Menu, Vault, Workspace, WorkspaceLeaf } from 'obsidian';
-import { transform } from 'markmap-lib';
+import { Transformer } from 'markmap-lib';
 import { Markmap } from 'markmap-view';
 import { INode } from 'markmap-common';
 import { FRONT_MATTER_REGEX, MD_VIEW_TYPE, MM_VIEW_TYPE } from './constants';
 import ObsidianMarkmap from './obsidian-markmap-plugin';
-import { createSVG, getComputedCss, removeExistingSVG } from './markmap-svg';
+import { createSVG, removeExistingSVG } from './markmap-svg';
 import { copyImageToClipboard } from './copy-image';
 import { MindMapSettings } from './settings';
-import { IMarkmapOptions } from 'markmap-view/types/types';
 
 export default class MindmapView extends ItemView {
     filePath: string;
@@ -169,21 +168,22 @@ export default class MindmapView extends ItemView {
     }
     
     async transformMarkdown() {
-        const { root, features } = transform(this.currentMd);
+        const { root, features } = new Transformer().transform(this.currentMd);
         this.obsMarkmap.updateInternalLinks(root);
         return { root, features };
     }
     
     async renderMarkmap(root: INode, svg: SVGElement) {
-        const { font } = getComputedCss(this.containerEl);
-        const options: IMarkmapOptions = {
-            autoFit: false,
-            duration: 10,
-            nodeFont: font,
-            nodeMinHeight: this.settings.nodeMinHeight ?? 16,
-            spacingVertical: this.settings.spacingVertical ?? 5,
-            spacingHorizontal: this.settings.spacingHorizontal ?? 80,
-            paddingX: this.settings.paddingX ?? 8
+        const options = {
+          ...Markmap.defaultOptions,
+          ...{
+              autoFit: false,
+              duration: 10,
+              nodeMinHeight: this.settings.nodeMinHeight ?? 16,
+              spacingVertical: this.settings.spacingVertical ?? 5,
+              spacingHorizontal: this.settings.spacingHorizontal ?? 80,
+              paddingX: this.settings.paddingX ?? 8
+            }
           };
           try {
             const markmapSVG = Markmap.create(svg, options, root);

--- a/src/mindmap-view.ts
+++ b/src/mindmap-view.ts
@@ -66,8 +66,8 @@ export default class MindmapView extends ItemView {
     async onOpen() {
         this.obsMarkmap = new ObsidianMarkmap(this.vault);
         this.registerActiveLeafUpdate();
+        this.workspace.onLayoutReady(() => this.update()),
         this.listeners = [
-            this.workspace.on('layout-ready', () => this.update()),
             this.workspace.on('resize', () => this.update()),
             this.workspace.on('css-change', () => this.update()),
             this.leaf.on('group-change', (group) => this.updateLinkedLeaf(group, this))

--- a/src/obsidian-markmap-plugin.ts
+++ b/src/obsidian-markmap-plugin.ts
@@ -11,13 +11,13 @@ export default class ObsidianMarkmap {
 
     updateInternalLinks(node: INode) {
         this.replaceInternalLinks(node);
-        if(node.c){
-            node.c.forEach(n => this.updateInternalLinks(n));
+        if(node.children){
+            node.children.forEach(n => this.updateInternalLinks(n));
         }
     }
 
     private replaceInternalLinks(node: INode){
-        const matches = this.parseValue(node.v);
+        const matches = this.parseValue(node.content);
         for (let i = 0; i < matches.length; i++) {
             const match = matches[i];
             const isWikiLink = match.groups['wikitext'];
@@ -28,7 +28,7 @@ export default class ObsidianMarkmap {
             }
             const url = `obsidian://open?vault=${this.vaultName}&file=${isWikiLink ? encodeURI(getLinkpath(linkPath)) : linkPath}`;
             const link = `<a href=\"${url}\">${linkText}</a>`;
-            node.v = node.v.replace(match[0], link);
+            node.content = node.content.replace(match[0], link);
         }
     }
 


### PR DESCRIPTION
Upgrading to be able to take advantage of newer features in markmap. https://markmap.js.org/

This has no new functionality and no changes, it just upgrades the markmap dependency. A follow up PR may then have new functionality such as setting expanded levels in the mind map.



EDIT - the below is now fixed also in the 2nd commit.

Note before and after this PR I was seeing the following issue when running `npm run dev` (using nvm ``)

Errors/warnings on master:
```
bundles src/main.ts → dist...
(!) Circular dependencies
node_modules/d3-selection/src/selection/index.js -> node_modules/d3-selection/src/selection/select.js -> node_modules/d3-selection/src/selection/index.js
node_modules/d3-selection/src/selection/index.js -> node_modules/d3-selection/src/selection/selectAll.js -> node_modules/d3-selection/src/selection/index.js
node_modules/d3-selection/src/selection/index.js -> node_modules/d3-selection/src/selection/filter.js -> node_modules/d3-selection/src/selection/index.js
...and 12 more
(!) Plugin typescript: @rollup/plugin-typescript TS2769: No overload matches this call.
  The last overload gave the following error.
    Argument of type '"layout-ready"' is not assignable to parameter of type '"quit"'.
src/mindmap-view.ts: (71:31)

71             this.workspace.on('layout-ready', () => this.update()),
                                 ~~~~~~~~~~~~~~

  node_modules/obsidian/obsidian.d.ts:4153:5
    4153     on(name: 'quit', callback: (tasks: Tasks) => any, ctx?: any): EventRef;
             ~~
    The last overload is declared here.

created dist in 5.2s
```
